### PR TITLE
Comment out POLICY TOOLKIT link in SidebarNavigation

### DIFF
--- a/src/app/components/SidebarNavigation.js
+++ b/src/app/components/SidebarNavigation.js
@@ -102,11 +102,11 @@ export default function SidebarNavigation({ sidebarOpen, setSidebarOpen, isMobil
                     Partners
                   </Link>
                 </li>
-                <li>
+                {/* <li>
                   <Link href="/policy-toolkit" className={`${styles.menuItem} text-xl font-bold uppercase block w-full p-2 ${section === 'policy-toolkit' ? styles.submenuItemActive : ''}`}>
                     POLICY TOOLKIT
                   </Link>
-                </li>
+                </li> */}
               </ul>
             </div>
           </li>


### PR DESCRIPTION
Comment out the POLICY TOOLKIT link in the SidebarNavigation component to prevent it from being displayed.