### PR TITLE
Update URL field mapping in ResourceDirectoryPage

### DIFF
--- a/src/app/resource-directory/page.js
+++ b/src/app/resource-directory/page.js
@@ -28,7 +28,7 @@ export default function ResourceDirectoryPage() {
           abbreviation: row.Abbreviation || '',
           name: row.Organization || '',
           description: row.Description || '',
-          url: row.URL || '',
+          url: row.Link || '',
         }))
       );
       setLoading(false);


### PR DESCRIPTION
Change the mapping of the URL field to use the Link property instead.