### PR TITLE
Fix mainHeading text in PolicyToolkitPage component

### DIFF
--- a/src/app/policy-toolkits/page.js
+++ b/src/app/policy-toolkits/page.js
@@ -11,7 +11,7 @@ export default function PolicyToolkitPage() {
     <main className="bg-[#fcfcfc] rounded-[10px] shadow-[6px_6px_0px_var(--quaternary-color)] h-auto border-0 p-4 sm:p-6 max-w-screen-xl mx-auto px-4 py-8">
       <ResearchSection
         csvUrl={toolkitCsvUrl}
-        mainHeading="Policy Toolkit"
+        mainHeading="Policy Toolkits"
         initialCategory="policy_recommendations"
         showInitialHeading={true}
         layout="grid"


### PR DESCRIPTION
Correct the mainHeading text from "Policy Toolkit" to "Policy Toolkits" for improved accuracy.